### PR TITLE
Support per-category privilege levels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 ===================================
-Question2Answer Role Markers v 0.1
+Question2Answer Role Markers v 1.2
 ===================================
 -----------
 Description
 -----------
-This is a plugin for **Question2Answer** that adds markers for special roles. 
+This is a plugin for **Question2Answer** that adds markers for special roles.
 
 --------
 Features
@@ -23,7 +23,7 @@ Installation
 #. Install Question2Answer_
 #. Get the source code for this plugin from github_, either using git_, or downloading directly:
 
-   - To download using git, install git and then type 
+   - To download using git, install git and then type
      ``git clone git://github.com/NoahY/q2a-role-markers.git role-markers``
      at the command prompt (on Linux, Windows is a bit different)
    - To download directly, go to the `project page`_ and click **Download**
@@ -53,4 +53,3 @@ About q2A
 Question2Answer is a free and open source platform for Q&A sites. For more information, visit:
 
 http://www.question2answer.org/
-

--- a/qa-marker-layer.php
+++ b/qa-marker-layer.php
@@ -4,10 +4,10 @@
 		function head_custom()
 		{
 			qa_html_theme_base::head_custom();
-			
+
 			$this->output('
 <style>
-'.qa_opt('marker_plugin_css_2').'				
+'.qa_opt('marker_plugin_css_2').'
 </style>');
 		}
 
@@ -15,98 +15,117 @@
 		{
 			if(isset($post['avatar']) && (($class == 'qa-q-view' && qa_opt('marker_plugin_a_qv')) || ($class == 'qa-q-item' && qa_opt('marker_plugin_a_qi')) || ($class == 'qa-a-item' && qa_opt('marker_plugin_a_a')) || ($class == 'qa-c-item' && qa_opt('marker_plugin_a_c')))) {
 				$uid = $post['raw']['userid'];
-				$image = $this->get_role_marker($uid,1);
+				$image = $this->get_role_marker($uid,1,$post);
 				$post['avatar'] = $image.@$post['avatar'];
 			}
 			qa_html_theme_base::post_avatar($post, $class, $prefix);
 		}
+
 		function post_meta($post, $class, $prefix=null, $separator='<BR/>')
 		{
 			if(isset($post['who']) && (($class == 'qa-q-view' && qa_opt('marker_plugin_w_qv')) || ($class == 'qa-q-item' && qa_opt('marker_plugin_w_qi')) || ($class == 'qa-a-item' && qa_opt('marker_plugin_w_a')) || ($class == 'qa-c-item' && qa_opt('marker_plugin_w_c')))) {
 				$handle = strip_tags($post['who']['data']);
 				$uid = $this->getuserfromhandle($handle);
-				$image = $this->get_role_marker($uid,2);
+				$image = $this->get_role_marker($uid,2,$post);
 				$post['who']['data'] = $image.$post['who']['data'];
-				
+
 			}
 			if(isset($post['who_2']) && (($class == 'qa-q-view' && qa_opt('marker_plugin_w_qv')) || ($class == 'qa-q-item' && qa_opt('marker_plugin_w_qi')) || ($class == 'qa-a-item' && qa_opt('marker_plugin_w_a')) || ($class == 'qa-c-item' && qa_opt('marker_plugin_w_c')))) {
 				$handle = strip_tags($post['who_2']['data']);
 				$uid = $this->getuserfromhandle($handle);
-				$image = $this->get_role_marker($uid,2);
+				$image = $this->get_role_marker($uid,2,$post);
 				$post['who_2']['data'] = $image.$post['who_2']['data'];
 			}
 
 			qa_html_theme_base::post_meta($post, $class, $prefix, $separator);
 		}
+
 		function ranking_label($item, $class)
 		{
 			if(qa_opt('marker_plugin_w_users') && $class == 'qa-top-users') {
 				$handle = strip_tags($item['label']);
 				$uid = $this->getuserfromhandle($handle);
-				$image = $this->get_role_marker($uid,2);
+				$image = $this->get_role_marker($uid,2,null);
 				$item['label'] = $image.$item['label'];
 			}
 			qa_html_theme_base::ranking_label($item, $class);
 		}
-				
+
 	// worker
-		
-		function get_role_marker($uid,$switch) {
+
+		function get_role_marker($uid,$switch,$post)
+		{
+			require_once QA_INCLUDE_DIR.'qa-app-users.php';
+			require_once QA_INCLUDE_DIR.'qa-db-selects.php';
+
 			if (QA_FINAL_EXTERNAL_USERS) {
 				$user = get_userdata( $uid );
 				if (isset($user->wp_capabilities['administrator']) || isset($user->caps['administrator']) || isset($user->allcaps['administrator'])) {
-					$level=qa_lang('users/level_admin');
-					$img = 'admin';
+					$userlevel = QA_USER_LEVEL_ADMIN;
 				}
 				elseif (isset($user->wp_capabilities['moderator']) || isset($user->caps['moderator'])) {
-					$level=qa_lang('users/level_moderator');
-					$img = 'moderator';
+					$userlevel = QA_USER_LEVEL_MODERATOR;
 				}
 				elseif (isset($user->wp_capabilities['editor']) || isset($user->caps['editor'])) {
-					$level=qa_lang('users/level_editor');
-					$img = 'editor';
+					$userlevel = QA_USER_LEVEL_EDITOR;
 				}
 				elseif (isset($user->wp_capabilities['contributor']) || isset($user->caps['contributor'])) {
-					$level=qa_lang('users/level_expert');
-					$img = 'expert';
+					$userlevel = QA_USER_LEVEL_EXPERT;
 				}
 				else
 					return;
-			} 
+			}
 			else {
-				$levelno = qa_db_read_one_value(
-					qa_db_query_sub(
-						'SELECT level FROM ^users WHERE userid=#',
-						$uid
-					),
-					true
-				);
-				$level = qa_user_level_string($levelno);
-				if ($level == qa_lang('users/level_admin') || $level == qa_lang('users/level_super'))
-					$img = 'admin';
-				elseif ($level == qa_lang('users/level_moderator'))
-					$img = 'moderator';
-				elseif ($level == qa_lang('users/level_editor'))
-					$img = 'editor';
-				elseif ($level == qa_lang('users/level_expert'))
-					$img = 'expert';
-				else
-					return; 
+				$cached_user = qa_db_get_pending_result('user'.$uid, qa_db_user_account_selectspec($uid, true));
+				$userlevel = @$cached_user['level'];
+
 			}
 
+			if ($post !== null) {
+				$categoryids = explode(',',$post['raw']['categoryids']);
+
+				if (count($categoryids)) {
+
+					$userlevels = qa_db_get_pending_result('user'.$uid.'levels', qa_db_user_levels_selectspec($uid, true));
+
+					$categorylevels=array(); // create a map
+					foreach ($userlevels as $ulevel)
+						if ($ulevel['entitytype']==QA_ENTITY_CATEGORY)
+							$categorylevels[$ulevel['entityid']]=$ulevel['level'];
+
+					foreach ($categoryids as $categoryid)
+						$userlevel = max($userlevel, @$categorylevels[$categoryid]);
+				}
+
+			}
+
+			if ($userlevel == QA_USER_LEVEL_ADMIN || $userlevel == QA_USER_LEVEL_SUPER)
+				$img = 'admin';
+			elseif ($userlevel == QA_USER_LEVEL_MODERATOR)
+				$img = 'moderator';
+			elseif ($userlevel == QA_USER_LEVEL_EDITOR)
+				$img = 'editor';
+			elseif ($userlevel == QA_USER_LEVEL_EXPERT)
+				$img = 'expert';
+			else
+				return;
+
+			$level = qa_html(qa_user_level_string($userlevel));
 			if($switch == 1)
-				return '<div class="qa-avatar-marker"><img title="'.qa_html($level).'" width="20" src="'.QA_HTML_THEME_LAYER_URLTOROOT.$img.'.png"/></div>';
-			else 
-				return '<span class="qa-who-marker qa-who-marker-'.$img.'" title="'.qa_html($level).'">'.qa_opt('marker_plugin_who_text').'</span>';
+				return '<div class="qa-avatar-marker"><img title="'.$level.'" width="20" src="'.QA_HTML_THEME_LAYER_URLTOROOT.$img.'.png"/></div>';
+			else
+				return '<span class="qa-who-marker qa-who-marker-'.$img.'" title="'.$level.'">'.qa_opt('marker_plugin_who_text').'</span>';
 		}
-		function getuserfromhandle($handle) {
+
+		function getuserfromhandle($handle)
+		{
 			require_once QA_INCLUDE_DIR.'qa-app-users.php';
-			
+
 			if (QA_FINAL_EXTERNAL_USERS) {
 				$publictouserid=qa_get_userids_from_public(array($handle));
 				$userid=@$publictouserid[$handle];
-				
-			} 
+
+			}
 			else {
 				$userid = qa_db_read_one_value(
 					qa_db_query_sub(

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -5,10 +5,10 @@
         Plugin URI: https://github.com/NoahY/q2a-roles
         Plugin Update Check URI: https://github.com/NoahY/q2a-roles/master/qa-plugin.php
         Plugin Description: Adds role markers to avatars and usernames
-        Plugin Version: 1.1
-        Plugin Date: 2011-12-29
-        Plugin Author: NoahY
-        Plugin Author URI: 
+        Plugin Version: 1.2
+        Plugin Date: 2013-10-04
+        Plugin Author: NoahY, Foivos S. Zakkak
+        Plugin Author URI:
         Plugin License: GPLv2
         Plugin Minimum Question2Answer Version: 1.4
 */
@@ -18,9 +18,9 @@
 			header('Location: ../../');
 			exit;
 	}
-	
-	qa_register_plugin_layer('qa-marker-layer.php', 'Marker Layer');	
-	
+
+	qa_register_plugin_layer('qa-marker-layer.php', 'Marker Layer');
+
 	qa_register_plugin_module('module', 'qa-marker-admin.php', 'qa_marker_admin', 'Role Markers');
 
 /*

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -2,8 +2,8 @@
 
 /*
         Plugin Name: Role Markers
-        Plugin URI: https://github.com/NoahY/q2a-roles
-        Plugin Update Check URI: https://github.com/NoahY/q2a-roles/master/qa-plugin.php
+        Plugin URI: https://github.com/NoahY/q2a-role-markers
+        Plugin Update Check URI: https://github.com/NoahY/q2a-role-markers/raw/master/qa-plugin.php
         Plugin Description: Adds role markers to avatars and usernames
         Plugin Version: 1.2
         Plugin Date: 2013-10-04


### PR DESCRIPTION
In the last version of question2answer a new feature was
introduced.  That feature enables users to have different
priviledges in different categories.  This commit extends
role-markers to support this new type of permissions and add
markers according to them.
